### PR TITLE
Adjust the markup to match the design pattern.

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,119 +21,125 @@
                                                 aria-current="page">Home</a>
                                 </li>
                                 <li class="top-level-entry-container"><button
+                                                id="technologyButton"
                                                 type="button"
                                                 class="ghost top-level-entry"
-                                                aria-haspopup="true">Technologies</button>
-                                        <ul class="subnav" aria-expanded="false">
+                                                aria-haspopup="menu"
+                                                aria-expanded="false">Technologies</button>
+                                        <ul class="subnav" role="menu" aria-labelledby="technologyButton">
                                                 <li data-item="Technologies"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web">Technologies
                                                                 Overview</a></li>
                                                 <li data-item="Technologies"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web/HTML">HTML</a>
                                                 </li>
                                                 <li data-item="Technologies"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web/CSS">CSS</a>
                                                 </li>
                                                 <li data-item="Technologies"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web/JavaScript">JavaScript</a>
                                                 </li>
                                                 <li data-item="Technologies"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web/Guide/Graphics">Graphics</a>
                                                 </li>
                                                 <li data-item="Technologies"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web/HTTP">HTTP</a>
                                                 </li>
                                                 <li data-item="Technologies"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web/API">APIs
                                                                 / DOM</a></li>
                                                 <li data-item="Technologies"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Mozilla/Add-ons/WebExtensions">Browser
                                                                 Extensions</a></li>
                                                 <li data-item="Technologies"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web/MathML">MathML</a>
                                                 </li>
                                         </ul>
                                 </li>
                                 <li class="top-level-entry-container"><button
+                                                id="referencesButton"
                                                 type="button"
                                                 class="ghost top-level-entry"
-                                                aria-haspopup="true">References
+                                                aria-haspopup="menu"
+                                                aria-expanded="false">References
                                                 &amp;
                                                 Guides</button>
-                                        <ul class="subnav" aria-expanded="false">
+                                        <ul class="subnav" role="menu" aria-labelledby="referencesButton">
                                                 <li data-item="References &amp; Guides"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Learn">Learn
                                                                 web development</a></li>
                                                 <li data-item="References &amp; Guides"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web/Tutorials">Tutorials</a>
                                                 </li>
                                                 <li data-item="References &amp; Guides"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web/Reference">References</a>
                                                 </li>
                                                 <li data-item="References &amp; Guides"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web/Guide">Developer
                                                                 Guides</a></li>
                                                 <li data-item="References &amp; Guides"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web/Accessibility">Accessibility</a>
                                                 </li>
                                                 <li data-item="References &amp; Guides"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Games">Game
                                                                 development</a></li>
                                                 <li data-item="References &amp; Guides"
-                                                        role="menuitem"><a
+                                                        role="none"><a role="menuitem"
                                                                 href="/en-US/docs/Web">...more
                                                                 docs</a></li>
                                         </ul>
                                 </li>
                                 <li class="top-level-entry-container"><button
+                                                id="feedbackButton"
                                                 type="button"
                                                 class="ghost top-level-entry"
-                                                aria-haspopup="true">Feedback</button>
-                                        <ul class="subnav" aria-expanded="false">
-                                                <li data-item="Feedback" role="menuitem">
-                                                        <a
+                                                aria-haspopup="menu"
+                                                aria-expanded="false">Feedback</button>
+                                        <ul class="subnav" role="menu" aria-labelledby="feedbackButton">
+                                                <li data-item="Feedback" role="none">
+                                                        <a role="menuitem"
                                                                 href="/en-US/docs/MDN/Feedback">Send
                                                                 Feedback</a></li>
-                                                <li data-item="Feedback" role="menuitem">
-                                                        <a target="_blank"
+                                                <li data-item="Feedback" role="none">
+                                                        <a role="menuitem" target="_blank"
                                                                 rel="noopener noreferrer"
                                                                 href="https://support.mozilla.org/">Get
                                                                 Firefox help 🌐</a></li>
-                                                <li data-item="Feedback" role="menuitem">
-                                                        <a target="_blank"
+                                                <li data-item="Feedback" role="none">
+                                                        <a role="menuitem" target="_blank"
                                                                 rel="noopener noreferrer"
                                                                 href="https://stackoverflow.com/">Get
                                                                 web development help
                                                                 🌐</a></li>
-                                                <li data-item="Feedback" role="menuitem">
-                                                        <a
+                                                <li data-item="Feedback" role="none">
+                                                        <a role="menuitem"
                                                                 href="/en-US/docs/MDN/Community">Join
                                                                 the MDN
                                                                 community</a>
                                                 </li>
-                                                <li data-item="Feedback" role="menuitem">
-                                                        <a target="_blank"
+                                                <li data-item="Feedback" role="none">
+                                                        <a role="menuitem" target="_blank"
                                                                 rel="noopener noreferrer"
                                                                 href="https://github.com/mdn/sprints/issues/new?template=issue-template.md&amp;projects=mdn/sprints/2&amp;labels=user-report&amp;title=%2Fen-US">Report
                                                                 a content problem 🌐</a>
                                                 </li>
-                                                <li data-item="Feedback" role="menuitem">
-                                                        <a target="_blank"
+                                                <li data-item="Feedback" role="none">
+                                                        <a role="menuitem" target="_blank"
                                                                 rel="noopener noreferrer"
                                                                 href="https://github.com/mdn/kuma/issues/new/choose">Report
                                                                 an

--- a/js/menu.js
+++ b/js/menu.js
@@ -20,7 +20,7 @@
   function hideSubMenuItems(subnavList) {
     Array.from(subnavList).forEach((element) => {
       element.classList.add("hidden");
-      element.setAttribute("aria-expanded", false);
+      element.previousElementSibling.setAttribute("aria-expanded", false);
     });
   }
 
@@ -57,9 +57,9 @@
       } else if (target.classList.contains("top-level-entry")) {
         const subnav = target.nextElementSibling;
         if (subnav) {
-          const ariaExpandedState = subnav.getAttribute("aria-expanded");
+          const ariaExpandedState = target.getAttribute("aria-expanded");
           subnav.classList.toggle("hidden");
-          subnav.setAttribute(
+          target.setAttribute(
             "aria-expanded",
             ariaExpandedState === "true" ? false : true
           );


### PR DESCRIPTION
- The menu items go on the `a` elements, not the `li`.
- The `ul` is the menu. This role was previously missing.
- The `button` gets the `aria-expanded` and labels the menu.

Closes #2.